### PR TITLE
Migrate SPE scripts to Docker Compose v2

### DIFF
--- a/bin/spe.bat
+++ b/bin/spe.bat
@@ -39,7 +39,7 @@ for %%A in (%*) do (
 )
 cd %PROJECT_DIR%/deploy
 echo starting s-pipes-editor-ui with scripts %CUSTOM_SCRIPT_PATHS%
-docker-compose --env-file=.env up
+docker compose --env-file=.env up
 :eof
 
 

--- a/bin/spe.sh
+++ b/bin/spe.sh
@@ -34,6 +34,6 @@ done
 
 
 cd $PROJECT_DIR/deploy
-CUSTOM_SCRIPT_PATHS="$CUSTOM_SCRIPT_PATHS" docker-compose --env-file=.env up
+CUSTOM_SCRIPT_PATHS="$CUSTOM_SCRIPT_PATHS" docker compose --env-file=.env up
 cd
 


### PR DESCRIPTION
Migrate remaining scripts to Docker Compose v2, missed in #118
![docker-compose-v2-scripts](https://github.com/user-attachments/assets/47914dd0-0413-4c15-b74c-4fef36912869)
