### PR TITLE
Refactor Spinner

### DIFF
--- a/src/components/Loading.jsx
+++ b/src/components/Loading.jsx
@@ -1,6 +1,6 @@
 import Spinner from "./spinner/Spinner";
 import { DelayRender } from "./DelayRender";
 
-const Loading = DelayRender(Spinner, 0);
+const Loading = DelayRender(Spinner, 300);
 
 export default Loading;

--- a/src/components/spinner/Spinner.css
+++ b/src/components/spinner/Spinner.css
@@ -13,7 +13,7 @@
   justify-content: center;
   height: 100vh;
   width: 100vw;
-  position: absolute;
+  position: fixed;
   top: 0;
   left: 0;
 }

--- a/src/components/spinner/Spinner.css
+++ b/src/components/spinner/Spinner.css
@@ -1,0 +1,28 @@
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+.spinner-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  width: 100vw;
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
+.spinner {
+  border: 4px solid rgba(0, 0, 0, 0.1);
+  border-top: 4px solid #3498db;
+  border-radius: 50%;
+  width: var(--size);
+  height: var(--size);
+  animation: spin 1s linear infinite;
+}

--- a/src/components/spinner/Spinner.jsx
+++ b/src/components/spinner/Spinner.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import "./Spinner.css";
 
 const sizeMap = {
   small: "20px",
@@ -9,37 +10,16 @@ const sizeMap = {
 const Spinner = ({ color = "#3498db", size = "middle", style }) => {
   const spinnerSize = sizeMap[size] || sizeMap.middle;
 
-  const spinnerKeyframes = `
-    @keyframes spin {
-      0% { transform: rotate(0deg); }
-      100% { transform: rotate(360deg); }
-    }
-  `;
-
-  const spinnerStyle = {
-    border: "4px solid rgba(0, 0, 0, 0.1)",
-    borderTop: `4px solid ${color}`,
-    borderRadius: "50%",
-    width: spinnerSize,
-    height: spinnerSize,
-    animation: "spin 1s linear infinite",
-  };
-
-  const containerStyle = {
-    display: "flex",
-    alignItems: "center",
-    justifyContent: "center",
-    height: "100vh",
-    width: "100vw",
-    position: "absolute",
-    top: 0,
-    left: 0,
-  };
-
   return (
-    <div style={containerStyle}>
-      <div style={{ ...spinnerStyle, ...style }}></div>
-      <style>{spinnerKeyframes}</style>
+    <div className="spinner-container">
+      <div
+        className="spinner"
+        style={{
+          "--size": spinnerSize,
+          ...style,
+          borderTopColor: color,
+        }}
+      />
     </div>
   );
 };

--- a/src/components/spinner/Spinner.jsx
+++ b/src/components/spinner/Spinner.jsx
@@ -2,9 +2,9 @@ import React from "react";
 import "./Spinner.css";
 
 const sizeMap = {
-  small: "20px",
-  middle: "40px",
-  large: "60px",
+  small: "40px",
+  middle: "60px",
+  large: "80px",
 };
 
 const Spinner = ({ color = "#3498db", size = "middle", style }) => {

--- a/src/components/treebeard/ScriptsTree.jsx
+++ b/src/components/treebeard/ScriptsTree.jsx
@@ -8,7 +8,6 @@ import Rest from "../../rest/Rest";
 import ScriptActionsModuleModal from "../modal/ScriptActionsModuleModal";
 import Loading from "../Loading";
 import ErrorModal from "../modal/ErrorModal";
-import Spinner from "react-bootstrap/Spinner";
 
 class ScriptsTree extends React.Component {
   constructor(props) {

--- a/src/components/treebeard/ScriptsTree.jsx
+++ b/src/components/treebeard/ScriptsTree.jsx
@@ -8,6 +8,7 @@ import Rest from "../../rest/Rest";
 import ScriptActionsModuleModal from "../modal/ScriptActionsModuleModal";
 import Loading from "../Loading";
 import ErrorModal from "../modal/ErrorModal";
+import Spinner from "react-bootstrap/Spinner";
 
 class ScriptsTree extends React.Component {
   constructor(props) {
@@ -97,7 +98,7 @@ class ScriptsTree extends React.Component {
 
   render() {
     if (this.state.data.length === 0) {
-      return <Loading size={"large"} style={{ margin: "auto", position: "absolute", inset: "0px", zIndex: 9000 }} />;
+      return <Loading />;
     } else {
       return (
         <Fragment>

--- a/src/pages/ExecutionsPage.jsx
+++ b/src/pages/ExecutionsPage.jsx
@@ -14,7 +14,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faMugHot, faEdit, faQuestion } from "@fortawesome/free-solid-svg-icons";
 import { Link } from "react-router-dom";
 import dayjs from "dayjs";
-import Spinner from "../components/spinner/Spinner.jsx";
+import Loading from "../components/Loading.jsx";
 
 const ExecutionsPage = () => {
   const [data, setData] = useState([]);
@@ -29,7 +29,7 @@ const ExecutionsPage = () => {
   }, []);
 
   if (loading) {
-    return <Spinner />;
+    return <Loading />;
   }
 
   return (

--- a/src/pages/ScriptPage.jsx
+++ b/src/pages/ScriptPage.jsx
@@ -630,9 +630,7 @@ class Script extends React.Component {
     };
     return (
       <div>
-        {this.state.isLoaded === false && (
-          <Loading size={"large"} style={{ margin: "auto", position: "absolute", inset: "0px", zIndex: 9000 }} />
-        )}
+        {this.state.isLoaded === false && <Loading />}
         <NavbarMenu />
 
         <ToastContainer position="top-end" className="p-3" style={{ zIndex: 100 }}>


### PR DESCRIPTION
Goal of current ticket:

- Fix the position of the spinner
![loader](https://github.com/user-attachments/assets/93bcde00-28ca-485d-a3b1-8884ba792ff8)
- Refactor css styles to the separate Spinner.css file
- Update size map, because the default size was indeed small
- Remove unnecessary css styles from the component that uses spinner
- Update DelayRender time for better user experience, because it can prevent the spinner from flashing briefly before the content loads.
- Use Loading component instead of Spinner, because it is a wrapper for DelayRender component that uses Spinner.