### PR TITLE
[#199] Fix modules not being able to be edited in some cases

### DIFF
--- a/src/pages/ScriptPage.tsx
+++ b/src/pages/ScriptPage.tsx
@@ -212,8 +212,8 @@ class Script extends React.Component {
         variables: n[MODULE_VARIABLES],
         icon: "/icons/" + icon,
         menu: true,
-        scriptPath: n[SCRIPT_PATH] ?? null,
-        parent: n[GROUP] ?? null,
+        scriptPath: n[SCRIPT_PATH],
+        parent: n[GROUP],
         validation: this.state.validationMap.get(n["@id"]),
       },
       selectable: false,
@@ -472,7 +472,7 @@ class Script extends React.Component {
             //TODO modal with style
             if (ele.data("scriptPath") === this.state.file) {
               alert("Script path is the same as actual one");
-            } else if (ele.data("scriptPath") === null) {
+            } else if (ele.data("scriptPath") === undefined) {
               alert("Script path is not defined");
             } else {
               window.location.href = "?file=" + ele.data("scriptPath");
@@ -818,8 +818,8 @@ class Script extends React.Component {
         <SFormsModal
           moduleTypeUri={this.state.moduleTypeUri}
           moduleUri={this.state.moduleUri}
-          scriptPath={this.state.fileEdit !== null ? this.state.fileEdit : this.state.file}
-          executionScriptPath={this.state.fileEdit !== null ? this.state.file : undefined}
+          scriptPath={this.state.fileEdit != null ? this.state.fileEdit : this.state.file}
+          executionScriptPath={this.state.fileEdit != null ? this.state.file : undefined}
         />
 
         <SFormsFunctionModal scriptPath={this.state.file} functionUri={this.state.functionUri} />


### PR DESCRIPTION
Resolves https://github.com/kbss-cvut/s-pipes-editor-ui/issues/199
s-pipes-editor-ui can't work with `undefined` value in `scriptPath`, which may happen if it hasn't been set on the backend. So I'm setting it to null, which can be processed by the frontend.