### PR TITLE
Fix module names being incorrect due to # sign

### DIFF
--- a/src/pages/ScriptPage.tsx
+++ b/src/pages/ScriptPage.tsx
@@ -198,7 +198,7 @@ class Script extends React.Component {
       }
     }
 
-    const label = n[LABEL] === undefined ? n["@id"].toString().split("/").reverse()[0] : n[LABEL];
+    const label = n[LABEL] === undefined ? n["@id"].toString().split(/[#\/]/).reverse()[0] : n[LABEL];
     const icon = ICONS_MAP[n[COMPONENT]] === undefined ? "beer.png" : ICONS_MAP[n[COMPONENT]];
 
     newNodes.push({


### PR DESCRIPTION
Resolves https://github.com/kbss-cvut/s-pipes-editor-ui/issues/220

Now, even with # signs in url module names would be correctly displayed

<img width="324" height="703" alt="image" src="https://github.com/user-attachments/assets/8cf1a44c-8edb-4d73-88a1-e87609c64012" />
